### PR TITLE
Firefox does not fire load after $(document).ready

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,9 +1,9 @@
-$(document).ready(function () {
+// Preloader js    
+$(window).on('load', function () {
+    $('.preloader').fadeOut(100);
+});
 
-    // Preloader js    
-    $(window).on('load', function () {
-        $('.preloader').fadeOut(100);
-    });
+$(document).ready(function () {
 
     // autohiding navbar on mobile devices
     $('.navbar-collapse a').click(function () {


### PR DESCRIPTION
to fade out preload in Firefox, $(window).on('load', function () { must be defined early enough